### PR TITLE
Add public rpc, public indexer api, and validator miss dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Syncing a new node may not work if the peers of other nodes are filled up, so pa
 - `tcp://42d3d815638e34ee8625e88713d4c31bee9ba490@88.99.3.143:26609` (spidey)
 - `tcp://53c597a8ef7d237ed829edcbb708df654a70381c@135.181.215.152:26656` (Node Guardians)
 
-
 ```bash
 persistent_peers = "tcp://0c4ce0c5ceb022564b111a4e4d0c0a66a9567dbe@65.109.117.113:26656,tcp://50e15e1639476ddc091d39c7e6faf4a1a3798235@38.242.152.80:26656,tcp://f47f2d1fd83f8063571145f90e984a74cba6310f@65.21.194.46:26656,tcp://7a3ce1bd42d8b2e09a21377f9cc2562b59f574a6@185.84.224.125:20056,tcp://b1edad170073d82537aaf3177e5042d857956adf@162.250.127.226:26656,tcp://52dc61ef963ddeaee15ff358b133fceb8eff5aa3@162.55.0.160:26656,tcp://f426c9a6287e2c2181ad64139c0963a07aea8b2a@65.108.147.137:26656,tcp://b7c3c9c98dc44880be42a4437e93e3330032ae19@135.125.189.84:26656,tcp://0a4ae55f81a2d5541c9f96274d1e51b1078c99df@167.235.35.48:26656,tcp://6bf567f926a18f95d5ea45837af189e3f5bd6f04@rpc-1.namada.nodes.guru:26656,tcp://38afb25360d9a698caf5a8934f4484e676352b8e@89.58.28.79:26656,tcp://f6efa383790ad014f0bf9394ec39d19f4f7e0f86@65.108.76.33:33356,tcp://ff0269406b70b76b991c8eb89918042554ecc26d@65.108.13.212:26656,tcp://9f7d037b6f6757d3ba6352d672b69b42b3e96126@54.195.152.187:26656,tcp://a55591635f84e0aff9b1567d0276fe32794e5ccf@65.109.28.34:26656,tcp://407240435312de546dd622f4228fbc6faccc8093@88.198.62.53:26656,tcp://53761db95fdb175ead7981ae5b92d6770f846e2f@37.27.63.150:26656,tcp://130efdc964211249504c64b83fdda4511239596e@88.198.54.190:26656,tcp://e6542c7f53d2b3bc0754f6a14b1533fcca64ef2b@147.135.65.3:26656,tcp://d4d14a3a8879527e42753d1bff8a69c12b4f3cd7@194.163.166.56:26656,tcp://783b88ab64a99d0efd7e077ecd3f1c9f787edab1@164.132.206.199:28656,tcp://cfdf31beafc3408a07194875c647da6a737c5520@65.108.68.214:28656"
 ```
@@ -101,10 +100,15 @@ Indexer endpoints
 - `tcp://c2d0b83418f6fb8b780f6bbdbdc2e0719f967824@158.220.127.197:26656` (UniqNodes)
 - `tcp://1fc8eb5685ea76faf20df5ed35d7622657e91b04@45.132.246.138:26656` (CosmicValidator)
 - `tcp://fb06663d96ee935816a8494fee4d81c0546a3731@217.197.107.144:26656` (StoneMac65)
-- 
+-
+
 ```bash
 persistent_peers = "tcp://0c4ce0c5ceb022564b111a4e4d0c0a66a9567dbe@65.109.117.113:26656,tcp://50e15e1639476ddc091d39c7e6faf4a1a3798235@38.242.152.80:26656,tcp://f47f2d1fd83f8063571145f90e984a74cba6310f@65.21.194.46:26656,tcp://7a3ce1bd42d8b2e09a21377f9cc2562b59f574a6@185.84.224.125:20056,tcp://b1edad170073d82537aaf3177e5042d857956adf@162.250.127.226:26656,tcp://52dc61ef963ddeaee15ff358b133fceb8eff5aa3@162.55.0.160:26656,tcp://f426c9a6287e2c2181ad64139c0963a07aea8b2a@65.108.147.137:26656,tcp://b7c3c9c98dc44880be42a4437e93e3330032ae19@135.125.189.84:26656,tcp://0a4ae55f81a2d5541c9f96274d1e51b1078c99df@167.235.35.48:26656,tcp://6bf567f926a18f95d5ea45837af189e3f5bd6f04@rpc-1.namada.nodes.guru:26656,tcp://38afb25360d9a698caf5a8934f4484e676352b8e@89.58.28.79:26656,tcp://f6efa383790ad014f0bf9394ec39d19f4f7e0f86@65.108.76.33:33356,tcp://ff0269406b70b76b991c8eb89918042554ecc26d@65.108.13.212:26656,tcp://9f7d037b6f6757d3ba6352d672b69b42b3e96126@54.195.152.187:26656,tcp://a55591635f84e0aff9b1567d0276fe32794e5ccf@65.109.28.34:26656,tcp://407240435312de546dd622f4228fbc6faccc8093@88.198.62.53:26656,tcp://53761db95fdb175ead7981ae5b92d6770f846e2f@37.27.63.150:26656,tcp://130efdc964211249504c64b83fdda4511239596e@88.198.54.190:26656,tcp://e6542c7f53d2b3bc0754f6a14b1533fcca64ef2b@147.135.65.3:26656,tcp://d4d14a3a8879527e42753d1bff8a69c12b4f3cd7@194.163.166.56:26656,tcp://783b88ab64a99d0efd7e077ecd3f1c9f787edab1@164.132.206.199:28656,tcp://fc8b5a2bc8e6ee1be6416b4c2a87360e904e0238@84.247.134.192:26656"
 ```
+
+## Validator Miss Dashboard
+
+- https://cosmostation.github.io/namadatools/
 
 ## Explorer
 
@@ -123,8 +127,8 @@ persistent_peers = "tcp://0c4ce0c5ceb022564b111a4e4d0c0a66a9567dbe@65.109.117.11
 - `https://rpc-namada-se.lgns.net/` (Luganodes)
 - `https://rpc.namada-expedition.tm.p2p.org/` (P2P.ORG)
 - `https://rpc.namada-expedition.tm.p2p.world/` (P2P.ORG)
-- `http://173.212.245.122:26657/`  (didbit)
-
+- `http://173.212.245.122:26657/` (didbit)
+- `https://rpc-namada.cosmostation.io` (Cosmostation)
 
 ## Indexer
 
@@ -133,6 +137,7 @@ persistent_peers = "tcp://0c4ce0c5ceb022564b111a4e4d0c0a66a9567dbe@65.109.117.11
 - `https://namada-indexer.denodes.xyz/block/last` (deNodes)
 - `https://namada-se-indexer.citadel.one/` (CitadelOne)
 - `https://namada-indexer.dsrvlabs.dev/` (DSRVLabs)
+- `https://api-namada.cosmostation.io` (Cosmostation)
 
 ## Creating the genesis files (advanced)
 
@@ -150,8 +155,6 @@ In order to create the genesis files for the expedition, the following steps wer
 ## Explorer
 
 - `http://namada.blog` (StoneMac65)
-
-
 
 ## How to create the chain-id from the genesis files
 


### PR DESCRIPTION
## Namda Tools for Validator Miss Checking 

>  we made validators miss dashboard for checking current epoch uptime. (very similar tenderduty but not tenderduty :rofl: 
> check your miss count and should prevent being not to increse above `864`

*  https://cosmostation.github.io/namadatools/

## Namda Public Endpoints 

**RPC :** 
- https://rpc-namada.cosmostation.io/

**API :** 
- https://api-namada.cosmostation.io/block/last

**CUSTOM API HANDLE :** 
- https://api-namada.cosmostation.io/chain_info -> viewing for validator liveness params and threshold
- https://api-namada.cosmostation.io/validator_siging_infos -> check missed block counter such as signing_infos

**VALIDATOR JAIL THRESSHOLD DESCRIPRITON** 
```rust
 // Derive the actual missing votes limit from the percentage
    let missing_votes_threshold = ((Dec::one() - params.liveness_threshold)
        * params.liveness_window_check)

...
...
...
    // Jail inactive validators
    let validators_to_jail = liveness_sum_missed_votes_handle()
        .iter(storage)?
        .filter_map(|entry| {
            let (address, missed_votes) = entry.ok()?;

            // Check if validator failed to match the threshold and jail
            // them
            if missed_votes >= missing_votes_threshold {
                Some(address)
            } else {
                None
            }
        })
        .collect::<BTreeSet<_>>();
```